### PR TITLE
Enable reapers for Rails 6 apps

### DIFF
--- a/lib/simple/sql/monkey_patches.rb
+++ b/lib/simple/sql/monkey_patches.rb
@@ -13,7 +13,6 @@ module Simple::SQL::MonkeyPatches
   end
 end
 
-# rubocop:disable Lint/DuplicateMethods
 case ActiveRecord.gem_version.to_s
 when /^4/
   :nop
@@ -34,22 +33,4 @@ when /^5.2/
       Simple::SQL::MonkeyPatches.warn "simple-sql disables reapers for all connection pools, see https://github.com/rails/rails/issues/33600"
     end
   end
-
-when /^6/
-  unless defined?(ActiveRecord::ConnectionAdapters::ConnectionPool::Reaper)
-    raise "Make sure to properly require active-record first"
-  end
-
-  # Rails6 fixes the issue w/reapers leaking threads; by properly cleaning up these threads
-  # (or  so one hopes after looking at connection_pool.rb). However, in the interest of simple-sql
-  # being more or less ActiveRecord agnostic we disable reaping here as well. (Also, that code
-  # looks pretty complex to me).
-  class ActiveRecord::ConnectionAdapters::ConnectionPool::Reaper
-    def run
-      return unless frequency && frequency > 0
-
-      Simple::SQL::MonkeyPatches.warn "simple-sql disables reapers for all connection pools, see https://github.com/rails/rails/issues/33600"
-    end
-  end
 end
-# rubocop:enable Lint/DuplicateMethods


### PR DESCRIPTION
this monkey patch disables reapers for PM and AC (apps left on rails 6 in prod)