### PR TITLE
Add ostruct as a dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -89,6 +89,7 @@ GEM
     unicode-display_width (2.4.2)
 
 PLATFORMS
+  arm64-darwin-24
   x86_64-linux
 
 DEPENDENCIES

--- a/simple-sql.gemspec
+++ b/simple-sql.gemspec
@@ -38,4 +38,6 @@ Gem::Specification.new do |gem|
 
   activerecord_specs = ENV["SIMPLE_SQL_ACTIVERECORD_SPECS"] || ''
   gem.add_dependency 'activerecord', '>= 5.2.4.5', *(activerecord_specs.split(","))
+
+  gem.add_dependency 'ostruct', '~> 0.6'
 end


### PR DESCRIPTION
Otherwise ruby 3.2 apps that include this gem won't work